### PR TITLE
Spool down threads when exiting

### DIFF
--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -132,7 +132,7 @@ module StatHat
       @que.close
 
       @pool.each do |th|
-        th.join
+        th.join(5)
       end
     end
 
@@ -175,5 +175,13 @@ module StatHat
       return unless @parsed.nil?
       @parsed = JSON.parse(@body)
     end
+  end
+end
+
+%w[INT TERM].each do |signal|
+  old_handler = trap(signal) do
+    puts "StatHat::Reporter.instance.finish in response to #{signal}"; STDOUT.flush
+    StatHat::Reporter.instance.finish
+    old_handler.call if old_handler.respond_to?(:call)
   end
 end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -75,7 +75,6 @@ module StatHat
 
     def initialize
       @que = Queue.new
-      @runlock = Mutex.new
       run_pool
     end
 
@@ -111,12 +110,10 @@ module StatHat
   private
 
     def run_pool
-      @runlock.synchronize { @running = true }
       @pool = []
       5.times do |i|
         @pool[i] = Thread.new do
-          while true do
-            point = @que.pop
+          while point = @que.pop do
             # XXX check for error?
             begin
               resp = Common::send_to_stathat(point[:url], point[:args])
@@ -126,23 +123,21 @@ module StatHat
             rescue
               pp $!
             end
-            @runlock.synchronize do
-              break unless @running
-            end
           end
         end
       end
     end
 
     def stop_pool
-      @runlock.synchronize { @running = false }
+      @que.close
+
       @pool.each do |th|
-        th.join if th && th.alive?
+        th.join
       end
     end
 
     def enqueue(url, args, cb=nil)
-      return false unless @running
+      return false if @que.closed?
       point = { url: url, args: args, cb: cb }
       @que << point
       true


### PR DESCRIPTION

This PR achieves two things.

1. it introduces a more reliable and simple way to coordinate between threads and shut them down
1. it defines behavior for TERM and INT signals - namely, it shuts down the thread pool, allowing them to finish their work first

So, it solves the problem described here: http://www.stathat.com/manual/code/ruby

>  the default StatHat::API Ruby methods are asynchronous. If you are using this gem in a script that is short-lived, you can use StatHat::SyncAPI to make synchronous calls to StatHat.

and clarified to me in a support ticket...

> It’s possible the asynchronous requests didn’t finish [before the script exited].

It's also good behavior to have in the general case such as in a web server, which might also lose some items in the queue

